### PR TITLE
Update for terraform 1.19 - Fixed Invalid reference from destroy provisioner

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ makefile
 # installer-files
 **/installer-files/*
 **/reference/*
+openshift_pull_secret.json
+ignition/show.txt
+make_cluster.txt

--- a/ignition/ignition.tf
+++ b/ignition/ignition.tf
@@ -5,6 +5,10 @@ locals {
 }
 
 resource "null_resource" "download_binaries" {
+
+  triggers = {
+    installer_workspace = local.installer_workspace
+  }
   provisioner "local-exec" {
     when    = create
     command = <<EOF
@@ -38,9 +42,12 @@ EOF
 
   provisioner "local-exec" {
     when    = destroy
-    command = "rm -rf ${local.installer_workspace}"
+    command = "rm -rf ${self.triggers.installer_workspace}"
+    environment = {
+      installer_workspace = self.triggers.installer_workspace
+    }
   }
-
+  
 }
 
 


### PR DESCRIPTION
│ Error: Invalid reference from destroy provisioner
│ 
│   on ignition/ignition.tf line 41, in resource "null_resource" "download_binaries":
│   41:     command = "rm -rf ${local.installer_workspace}"
│ 
│ Destroy-time provisioners and their connection configurations may only reference attributes of the related resource, via 'self', 'count.index', or 'each.key'.
│ 
│ References to other resources during the destroy phase can cause dependency cycles and interact poorly with create_before_destroy.